### PR TITLE
Fix return mask logic in notebook

### DIFF
--- a/le_registration.ipynb
+++ b/le_registration.ipynb
@@ -225,7 +225,7 @@
     "def filter_noise_points_weighted(points, eps: float = 3, min_samples: int = 2,\n",
     "                                 min_cluster_size: int = 55, return_mask: bool = False):\n",
     "    if len(points) == 0:\n",
-    "        return np.array([]), np.array([]) if not return_mask else (np.array([]), np.array([]), None)\n",
+    "        return (np.array([]), np.array([])) if not return_mask else (np.array([]), np.array([]), None)\n",
     "    db = DBSCAN(eps=eps, min_samples=min_samples).fit(points)\n",
     "    labels = db.labels_\n",
     "    unique_labels, counts = np.unique(labels[labels != -1], return_counts=True)\n",


### PR DESCRIPTION
## Summary
- fix tuple wrapping bug in `filter_noise_points_weighted`

## Testing
- `git show -n 1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68538aa0f19c832ba19b3d2b1d9fd78d